### PR TITLE
Remove split data dir with shut.rmtree() instead of os.rmdir()

### DIFF
--- a/generative_data_prep/data_prep/pipeline.py
+++ b/generative_data_prep/data_prep/pipeline.py
@@ -18,6 +18,7 @@ Data preparation pipeline for converting a jsonl file to tokenized hdf5 files co
 
 import os
 import random
+import shutil
 from multiprocessing import Pool
 from sys import platform
 from typing import List, Optional, Tuple
@@ -480,4 +481,4 @@ def pipeline_main(  # noqa: C901
         print(SEP_STR)
 
     if not keep_split_jsonls:
-        os.rmdir(split_dir)
+        shutil.rmtree(split_dir)


### PR DESCRIPTION
## Summary
os.rmdir() fails if the directory is not empty. Change that command to use shutil so we can delete the split jsonl files and save storage space


## PR Checklist
- [ X] My PR is less than 500 lines of code
- [ X] I have added sufficient comment as docstrings in my code
- [ X] I have made corresponding changes to the documentation

