### PR TITLE
Fail out with error if the OS kills any of the tokenization processes.

### DIFF
--- a/generative_data_prep/data_prep/pipeline.py
+++ b/generative_data_prep/data_prep/pipeline.py
@@ -19,7 +19,7 @@ Data preparation pipeline for converting a jsonl file to tokenized hdf5 files co
 import os
 import random
 import shutil
-from multiprocessing import Pool
+from multiprocessing import Pool, set_start_method
 from sys import platform
 from typing import List, Optional, Tuple
 
@@ -37,6 +37,8 @@ from generative_data_prep.utils import (
     large_file_shuffle,
     verify_output_dir,
 )
+
+set_start_method("spawn")
 
 
 def split_file_linux(num_splits: int, input_file_path: str, split_dir: str) -> None:
@@ -334,6 +336,7 @@ def pipeline_main(  # noqa: C901
     Raises:
         RuntimeError: If shuffling on RAM is not possible
     """
+    print(os.getpid())
     # print input file information
     input_file_size_in_bytes = os.stat(input_file_path).st_size
     input_file_size_in_gb = input_file_size_in_bytes / (1024**3)


### PR DESCRIPTION
## Summary
Right now, if one of the processes are killed because of OOM or for some various reason killed by the OS, then the software will silently hang and not fail out with an error. This PR works to fail out with an error to make sure the user can run with fewer multiprocessing workers to avoid OOM issues.


## PR Checklist
- [ ] My PR is less than 500 lines of code
- [ ] I have added sufficient comment as docstrings in my code
- [ ] I have made corresponding changes to the documentation
<!--TODO: Remove this once coverage tool checks are implemented -->
- [ ] I have written unit-tests to test all of my code
