### PR TITLE
Add category id rebalancing

### DIFF
--- a/generative_data_prep/utils/balance_hdf5_files.py
+++ b/generative_data_prep/utils/balance_hdf5_files.py
@@ -155,7 +155,7 @@ def balance_hdf5_files(hdf5_file_paths: List[str]) -> None:  # noqa: C901
                 # remove saved token_type_ids sequences so they are not used again
                 extra_category_seqs_np = extra_category_seqs_np[num_needed_seq:]
 
-    if len(extra_token_seqs_np) != 0 or len(extra_category_seqs_np) != 0:
+    if len(extra_token_seqs_np) != 0:
         raise ValueError("extra_token_seqs_np is non zero at the end of rebalancing")
     if remainder != 0:
         raise ValueError("remaineder is not 0 after finishing rebalancing")


### PR DESCRIPTION
## Summary
A previous https://github.com/sambanova/generative_data_prep/pull/31 added the option to add metadata about what category id each token is. This PR forgot to update the rebalancing stage to also rebalance the category id tokens, this PR is a fix for that.


## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation
- [ ] I have written unit-tests to test all of my code
