### PR TITLE
Jayr/bugfix/sha256 dir exists

### DIFF
--- a/generative_data_prep/utils/utils.py
+++ b/generative_data_prep/utils/utils.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import math
 import os
+import shutil
 from importlib.resources import files as importlib_files
 from subprocess import PIPE, run  # nosec
 from typing import Optional
@@ -332,6 +333,8 @@ def create_sha256(output_dir: str):
     files_to_hash = _get_walk_files_to_hash(output_dir)
 
     hash_dir = os.path.join(output_dir, "sha256")
+    if os.path.isdir(hash_dir):
+        shutil.rmtree(hash_dir)
     os.mkdir(hash_dir)
     output_file_hash = os.path.join(hash_dir, "files_metadata.json")
     file_info_dict = {}

--- a/generative_data_prep/utils/utils.py
+++ b/generative_data_prep/utils/utils.py
@@ -330,11 +330,10 @@ def create_sha256(output_dir: str):
     Returns:
         None
     """
-    files_to_hash = _get_walk_files_to_hash(output_dir)
-
     hash_dir = os.path.join(output_dir, "sha256")
     if os.path.isdir(hash_dir):
         shutil.rmtree(hash_dir)
+    files_to_hash = _get_walk_files_to_hash(output_dir)
     os.mkdir(hash_dir)
     output_file_hash = os.path.join(hash_dir, "files_metadata.json")
     file_info_dict = {}

--- a/generative_data_prep/utils/utils.py
+++ b/generative_data_prep/utils/utils.py
@@ -283,7 +283,7 @@ def _get_walk_files_to_hash(dir: str, filter: Optional[str] = None):
         hash_file_names = [
             (
                 os.path.join(foldername, filename),
-                relative_foldername + filename.split(".")[0] + ".txt",
+                relative_foldername + filename,
             )
             for filename in filenames
         ]


### PR DESCRIPTION
Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions.

## Summary
<!-- Provide a short summary of your changes -->
Since the sha256 metajson file already exists, it will error out unless the sha directory is deleted if the output directory already exists.

Also a small nit I had was that the file extensions were being saved differently in the SHA, which doesn't lead to any errors but wanted to fix that

## PR Checklist
- [x] My PR is less than 500 lines of code
- [x] I have added sufficient comment as docstrings in my code
- [x] I have made corresponding changes to the documentation
<!--TODO: Remove this once coverage tool checks are implemented -->
- [x] I have written unit-tests to test all of my code
