### PR TITLE
catch invalid git repository error

### DIFF
--- a/generative_data_prep/utils/logger.py
+++ b/generative_data_prep/utils/logger.py
@@ -57,10 +57,13 @@ def log_current_datetime():
 
 def log_git_commit_hash():
     """Log the current git commit hash."""
-    repo = git.Repo(os.path.abspath(__file__), search_parent_directories=True)
-    sha = repo.head.object.hexsha
     LOGGER.debug("Running Generative Data Prep repository: https://github.com/sambanova/generative_data_prep/")
-    LOGGER.debug(f"Git commit hash: {sha}")
+    try:
+        repo = git.Repo(os.path.abspath(__file__), search_parent_directories=True)
+        sha = repo.head.object.hexsha
+        LOGGER.debug(f"Git commit hash: {sha}")
+    except git.exc.InvalidGitRepositoryError:
+        LOGGER.debug("Git commit hash not found")
 
 
 def log_input_args(args):


### PR DESCRIPTION
## Summary
If the user pip install . this package, then it does not have access to a git repository and causes the logger to error out. To fix this, lets just not log the git repo hash if we do not have access to it. 

## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation

