### PR TITLE
fix bug

### DIFF
--- a/generative_data_prep/__main__.py
+++ b/generative_data_prep/__main__.py
@@ -30,7 +30,6 @@ from generative_data_prep.utils import (
     TOKENIZER_CLASSES,
     FileExtension,
     add_file_handler,
-    create_sha256,
     data_prep_arg_builder,
     get_config_file_path,
     log_current_datetime,
@@ -372,9 +371,6 @@ def main(args):
 
     log_metrics(metrics)
     log_elapsed_time()
-
-    # Create sha256 of all the files within the directory
-    create_sha256(args.output_path)
 
 
 if __name__ == "__main__":

--- a/generative_data_prep/data_prep/pipeline.py
+++ b/generative_data_prep/data_prep/pipeline.py
@@ -36,6 +36,7 @@ from generative_data_prep.utils import (
     BoundaryType,
     PackingConfig,
     balance_hdf5_files,
+    create_sha256,
     execute_and_return_stdout,
     large_file_shuffle,
     log_sep_str,
@@ -574,5 +575,8 @@ def pipeline_main(  # noqa: C901
     metadata_file_path = os.path.join(output_dir, "metadata.yaml")
     with open(metadata_file_path, "w") as file:
         yaml.dump(dataset_metadata_json, file, default_flow_style=False)
+
+    # Create sha256 of all the files within the directory
+    create_sha256(output_dir)
 
     return metrics


### PR DESCRIPTION
## Summary
Fix issue https://github.com/sambanova/generative_data_prep/issues/71


There is a bug when running generative_data_prep when running data_prep directly instead of pipeline.

This was introduced by this PR https://github.com/sambanova/generative_data_prep/pull/64, because it assumes the output is a directory.

Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/Users/zoltanc/Desktop/generative_data_prep/generative_data_prep/__main__.py", line 384, in <module> main(args) File "/Users/zoltanc/Desktop/generative_data_prep/generative_data_prep/__main__.py", line 377, in main create_sha256(args.output_path) File "/Users/zoltanc/Desktop/generative_data_prep/generative_data_prep/utils/utils.py", line 335, in create_sha256 os.mkdir(hash_dir) NotADirectoryError: [Errno 20] Not a directory: '/Users/zoltanc/Desktop/generative_data_prep/tests/examples/generative_tuning/tester/output.hdf5/sha256'

## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation
