### PR TITLE
Fix bug where for larger datasets the metrics are incorrect

### DIFF
--- a/generative_data_prep/data_prep/pipeline.py
+++ b/generative_data_prep/data_prep/pipeline.py
@@ -379,7 +379,7 @@ def multiprocess_data_prep(  # noqa: C901
             # If all the processes are done, break the loop
             if all(future.done() for future in futures):
                 if len(finished_futures) != len(futures):
-                    raise ValueError("All futures done, butinished futures set is not the same as all futures.")
+                    raise ValueError("All futures done, but finished futures set does not equal all futures list.")
                 break
             # Update the progress bar with how every many new articles were tokenized
             with num_tokenized_articles_lock:


### PR DESCRIPTION
## Summary
Fix for issue https://github.com/sambanova/generative_data_prep/issues/53

For small datasets the metrics worked correctly and matched with the output dataset, but for larger datasets the metrics would be really large numbers. 

After a worker had finished, we would continue to sum its metrics if any other worker is running. This means that for large datasets, the workers are unlikely to finish at the same time, and the metrics would continue summing and explode in size. 


## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation
