### PR TITLE
Add Dataset Size Requirements Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ To do this, include flags from only one of the two options below, only use one o
 - To specify the number of training splits and test splits directly, use the three flags `--num_training_splits=...`, `--num_dev_splits=...` and `--num_test_splits=...`
 - To specify the percentage of the data heldout for testing, you can specify `--dev_ratio=...` and `--test_ratio=0.1`, where 0.1 means that approximately 10% of the data will be included in the test splits. You can also specify the `--num_training_splits=...` flag to control the total number of training splits, but we recommend to let this default.
 
-### Flags
+### Key Flags
+
+- max_seq_length
+
+### All Flags
 <details>
   <summary>CLICK HERE to see flags</summary>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This software package is designed for preparing data that can be used to train g
 - [Introduction](#introduction)
 - [Input format](#input-format)
 - [End to end data preparation](#end-to-end-data-preparation)
-    - [Input Flags](#all-flags)
+    - [Input Flags](#flags)
 - [Tokenizing one file](#tokenizing-one-file)
     - [Input Flags](#tokenize-one-file-flags)
 - [Running tests](#running-tests)
@@ -133,7 +133,7 @@ With a sufficiently large dataset, you are generally fine with the defaults here
 Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in the `metadata.yaml` which dictates how large you can set the corresponding training hyper-parameter setting when you kick off a model training job!
 </details>
 
-### All Flags
+### Flags
 <details>
   <summary>CLICK HERE to see flags</summary>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This software package is designed for preparing data that can be used to train g
 - [Introduction](#introduction)
 - [Input format](#input-format)
 - [End to end data preparation](#end-to-end-data-preparation)
-    - [Input Flags](#flags)
+    - [Input Flags](#all-flags)
 - [Tokenizing one file](#tokenizing-one-file)
     - [Input Flags](#tokenize-one-file-flags)
 - [Running tests](#running-tests)
@@ -98,9 +98,36 @@ To do this, include flags from only one of the two options below, only use one o
 - To specify the number of training splits and test splits directly, use the three flags `--num_training_splits=...`, `--num_dev_splits=...` and `--num_test_splits=...`
 - To specify the percentage of the data heldout for testing, you can specify `--dev_ratio=...` and `--test_ratio=0.1`, where 0.1 means that approximately 10% of the data will be included in the test splits. You can also specify the `--num_training_splits=...` flag to control the total number of training splits, but we recommend to let this default.
 
-### Key Flags
+### Dataset Size Requirements
+When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set for training. It is *__necessary__* to know this maximum batch size so you can set it accordingly for your training job. 
 
-- max_seq_length
+#### How to Check and Set
+
+When kicking off a training job, you need to make sure that batch size hyper-parameter setting is __*no bigger*__ than the value of `max_batch_size_train` shown in the dataset `metadata.yaml` file.
+
+For example:
+```(shell)
+$ cat processed_data_directory/metadata.yaml
+
+max_batch_size_dev: null
+max_batch_size_train: 7
+max_seq_length: 1024
+number_of_dev_files: 0
+number_of_test_files: 0
+number_of_training_files: 32
+token_type_ids: true
+tokenizer_model_type: <class 'transformers.models.gpt2.configuration_gpt2.GPT2Config'>
+vocab_size: 50257
+```
+Here you can see that `max_batch_size_train` is 7, so the batch size hyper-parameter setting cannot be greater than 7.
+
+#### Explanation
+
+The dataset that you are providing will be split up across multiple hdf5 files based on the input parameters of the `pipeline` command.
+
+* `max_seq_length` - The maximum sequence length the model you are using can take for a single data point. 
+* `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the flags section.
+
 
 ### All Flags
 <details>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To do this, include flags from only one of the two options below, only use one o
 - To specify the percentage of the data heldout for testing, you can specify `--dev_ratio=...` and `--test_ratio=0.1`, where 0.1 means that approximately 10% of the data will be included in the test splits. You can also specify the `--num_training_splits=...` flag to control the total number of training splits, but we recommend to let this default.
 
 ### Dataset Size Requirements
-When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set for training. It is *__necessary__* to know this maximum batch size so you can set it accordingly for your training job. 
+When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set for training. It is *__necessary__* to know this maximum batch size so you can set it accordingly for your training job.
 
 #### How to Check and Set
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ With a sufficiently large dataset, you are generally fine with the defaults here
 
 <br /> The dataset that you are providing will be split up across multiple hdf5 files based on the input parameters of the `pipeline` command.
 
-* `max_seq_length` - The maximum sequence length the model you are using can take for a single data point. 
+* `max_seq_length` - The maximum sequence length the model you are using can take for a single data point.
 * `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the flags section.
 
 Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in the `metadata.yaml` which dictates how large you can set the corresponding training hyper-parameter setting when you kick off a model training job!

--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ To do this, include flags from only one of the two options below, only use one o
 - To specify the percentage of the data heldout for testing, you can specify `--dev_ratio=...` and `--test_ratio=0.1`, where 0.1 means that approximately 10% of the data will be included in the test splits. You can also specify the `--num_training_splits=...` flag to control the total number of training splits, but we recommend to let this default.
 
 ### Dataset Size Requirements
-When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set for training. It is *__necessary__* to know this maximum batch size so you can set it accordingly for your training job.
+When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set. Not all models expose the `batch_size` parameter, however for those that do, it is *__very important__* to know this maximum batch size and set `batch_size` accordingly.
 
 #### How to Check and Set
 
-When kicking off a training job, you need to make sure that batch size hyper-parameter setting is __*no bigger*__ than the value of `max_batch_size_train` shown in the dataset `metadata.yaml` file.
+When starting a training job, ensure that the `batch_size` hyper-parameter is __*no bigger*__ than the `max_batch_size_train` shown in `metadata.yaml`.
 
 For example:
 ```(shell)
-$ cat processed_data_directory/metadata.yaml
+$ cat <PROCESSED DATA DIRECTORY>/metadata.yaml
 
 max_batch_size_dev: null
 max_batch_size_train: 7
@@ -119,18 +119,18 @@ token_type_ids: true
 tokenizer_model_type: <class 'transformers.models.gpt2.configuration_gpt2.GPT2Config'>
 vocab_size: 50257
 ```
-Here you can see that `max_batch_size_train` is 7, so the batch size hyper-parameter setting cannot be greater than 7.
+Here you can see that `max_batch_size_train` is 7, so the `batch size` hyper-parameter cannot be greater than 7.
 
 #### Explanation
 <details>
-With a sufficiently large dataset, you are generally fine with the defaults here and can ignore. However, when the provided dataset is small (think ~1000 data points or less), you need to make sure you are setting the above values correctly or else you will likely run into a training error.
+With a sufficiently large dataset, you are generally fine with the defaults and can ignore. However, when the provided dataset is small (~1000 data points or less), you need to set the above values correctly or else you will likely run into a training error.
 
 <br /> The dataset that you are providing will be split up across multiple hdf5 files based on the input parameters of the `pipeline` command.
 
-* `max_seq_length` - The maximum sequence length the model you are using can take for a single data point.
-* `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the flags section.
+* `max_seq_length` - The maximum sequence length the model you are using can take for a single data point. See more in [flags](#flags) section.
+* `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the [flags](#flags) section.
 
-Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in the `metadata.yaml` which dictates how large you can set the corresponding training hyper-parameter setting when you kick off a model training job!
+Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in `metadata.yaml` which dictates how large you can set the corresponding `batch_size` hyper-parameter setting when starting a model training job!
 </details>
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -122,12 +122,16 @@ vocab_size: 50257
 Here you can see that `max_batch_size_train` is 7, so the batch size hyper-parameter setting cannot be greater than 7.
 
 #### Explanation
+<details>
+With a sufficiently large dataset, you are generally fine with the defaults here and can ignore. However, when the provided dataset is small (think ~1000 data points or less), you need to make sure you are setting the above values correctly or else you will likely run into a training error.
 
-The dataset that you are providing will be split up across multiple hdf5 files based on the input parameters of the `pipeline` command.
+<br /> The dataset that you are providing will be split up across multiple hdf5 files based on the input parameters of the `pipeline` command.
 
 * `max_seq_length` - The maximum sequence length the model you are using can take for a single data point. 
 * `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the flags section.
 
+Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in the `metadata.yaml` which dictates how large you can set the corresponding training hyper-parameter setting when you kick off a model training job!
+</details>
 
 ### All Flags
 <details>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ To do this, include flags from only one of the two options below, only use one o
 - To specify the percentage of the data heldout for testing, you can specify `--dev_ratio=...` and `--test_ratio=0.1`, where 0.1 means that approximately 10% of the data will be included in the test splits. You can also specify the `--num_training_splits=...` flag to control the total number of training splits, but we recommend to let this default.
 
 ### Dataset Size Requirements
-When preparing a dataset for training, different dataset sizes will dictate the maximum batch size you can set. Not all models expose the `batch_size` parameter, however for those that do, it is *__very important__* to know this maximum batch size and set `batch_size` accordingly.
+1. You need to ensure your input dataset is large enough to run one batch of training.
+2. Make sure that the number of sequences in the output dataset files satisfy this by checking `max_batch_size_train` in the `<OUTPUT_DIR>/metadata.yaml` file.
+3. Use this value to set `batch_size` accordingly when starting a training job!
 
 #### How to Check and Set
 
@@ -131,6 +133,8 @@ With a sufficiently large dataset, you are generally fine with the defaults and 
 * `input_packing_config` - Determines how to pack the provided data into sequences that will be split across the hdf5 files for training. See more in the [flags](#flags) section.
 
 Based on the size and strucutre of the dataset provided + these parameter settings, a different `max_batch_size_train` will be shown in `metadata.yaml` which dictates how large you can set the corresponding `batch_size` hyper-parameter setting when starting a model training job!
+
+**_Note:_**: Not all models trained in studio will expose the `batch_size` parameter. For those that don't you should ensure your `max_batch_size_train` is larger than the default batch size (generally 16).
 </details>
 
 ### Flags

--- a/generative_data_prep/__main__.py
+++ b/generative_data_prep/__main__.py
@@ -38,6 +38,7 @@ from generative_data_prep.utils import (
     log_input_args,
     log_metrics,
     log_sep_str,
+    log_training_details,
     verify_input_file,
     verify_output_dir,
     verify_output_file,
@@ -323,7 +324,7 @@ def main(args):
     category_to_id = get_categories(args.categories_path)
 
     if args.cmd == "pipeline":
-        metrics = pipeline_main(
+        metrics, dataset_metadata = pipeline_main(
             args.input_file_path,
             tokenizer,
             model_config,
@@ -371,6 +372,8 @@ def main(args):
 
     log_metrics(metrics)
     log_elapsed_time()
+    if args.cmd == "pipeline":
+        log_training_details(dataset_metadata)
 
 
 if __name__ == "__main__":

--- a/generative_data_prep/data_prep/pipeline.py
+++ b/generative_data_prep/data_prep/pipeline.py
@@ -471,7 +471,7 @@ def pipeline_main(  # noqa: C901
         RuntimeError: If shuffling on RAM is not possible
 
     Returns:
-        Metrics associated with tokenization
+        Metrics associated with tokenization, Dataset metadata
     """
     # print input file information
     dataset_metadata_json = {
@@ -657,4 +657,4 @@ def pipeline_main(  # noqa: C901
     # Create sha256 of all the files within the directory
     create_sha256(output_dir)
 
-    return metrics
+    return metrics, dataset_metadata_json

--- a/generative_data_prep/utils/__init__.py
+++ b/generative_data_prep/utils/__init__.py
@@ -32,6 +32,7 @@ from .logger import (
     log_input_args,
     log_metrics,
     log_sep_str,
+    log_training_details,
 )
 from .metadata_generation import DatasetMetadata
 from .path_verify import verify_input_file, verify_output_dir, verify_output_file
@@ -70,6 +71,7 @@ __all__ = [
     "log_metrics",
     "log_git_commit_hash",
     "log_elapsed_time",
+    "log_training_details",
     "log_sep_str",
     "get_config_file_path",
     "DatasetMetadata",

--- a/generative_data_prep/utils/logger.py
+++ b/generative_data_prep/utils/logger.py
@@ -19,6 +19,7 @@ import datetime
 import logging
 import logging.config
 import os
+from typing import Dict, Union
 
 import git
 
@@ -89,6 +90,17 @@ def get_header(header_name: str):
 def log_elapsed_time():
     """Log how much time it took to execute entire script."""
     LOGGER.info(f"Elapsed time: {datetime.datetime.now().replace(microsecond=0) - START_TIME.replace(microsecond=0)}")
+
+
+def log_training_details(dataset_metadata: Dict[str, Union[str, int, bool]]):
+    """Log training parameters that need to be used with this dataset."""
+    LOGGER.info(SEP_STR)
+    LOGGER.info("The dataset you have prepared requires you to set the following training parameters:")
+    LOGGER.info(f"    Max sequence length == {dataset_metadata['max_seq_length']}")
+    LOGGER.info(f"    Model vocabulary size == {dataset_metadata['vocab_size']}")
+    LOGGER.info(f"    Local batch size <= {dataset_metadata['max_batch_size_train']}")
+    LOGGER.info(f"    Number of RDUs (data parallel workers) {dataset_metadata['number_of_training_files']}")
+    LOGGER.info(f"    Do eval: {'True' if int(dataset_metadata['number_of_dev_files']) >= 1 else 'False'}")
 
 
 def log_sep_str():

--- a/generative_data_prep/utils/logger.py
+++ b/generative_data_prep/utils/logger.py
@@ -98,7 +98,7 @@ def log_training_details(dataset_metadata: Dict[str, Union[str, int, bool]]):
     LOGGER.info("The dataset you have prepared requires you to set the following training parameters:")
     LOGGER.info(f"    Max sequence length == {dataset_metadata['max_seq_length']}")
     LOGGER.info(f"    Model vocabulary size == {dataset_metadata['vocab_size']}")
-    LOGGER.info(f"    Local batch size <= {dataset_metadata['max_batch_size_train']}")
+    LOGGER.info(f"    Batch size <= {dataset_metadata['max_batch_size_train']}")
     LOGGER.info(f"    Number of RDUs (data parallel workers) {dataset_metadata['number_of_training_files']}")
     LOGGER.info(f"    Do eval: {'True' if int(dataset_metadata['number_of_dev_files']) >= 1 else 'False'}")
 


### PR DESCRIPTION
## Summary
Adding a section that explains the need to know `max_batch_size_train` when submitting a training job. Customers were running into issues with datasets that were too small, so this section concisely explains how to check the `max_batch_size_train` parameter when preparing your dataset. Additional explanation is provided in a collapsable `Explanation` section to give relevant context, but not overwhelm the reader who's just getting started. 

