### PR TITLE
update requirements to only require python>=3.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "sambanova-generative-data-prep"
 description = "Prepare data that can be used to train generative models."
 readme = "README.md"
-requires-python = ">=3.8.16"
+requires-python = ">=3.8.10"
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
Some machines only have python 3.8.10 on it, so lets see if the repo works with this python version and decrease requirements

## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation
