### PR TITLE
only grab num tokenized articles lock every 100 steps

### DIFF
--- a/generative_data_prep/data_prep/data_prep.py
+++ b/generative_data_prep/data_prep/data_prep.py
@@ -107,12 +107,16 @@ def data_prep_main(
 
     with Hdf5FileBuffer(output_file, max_seq_length, dump_categories) as hdf5_text_buffer:
         with open(input_file, "r") as reader:
-            for line in reader:
+            for i, line in enumerate(reader):
                 try:
                     hdf5_text_buffer.write(article_tokenizer(line))
-                    if num_tokenized_articles_lock is not None and num_tokenized_articles is not None:
+                    if (
+                        (i != 0 and i % 100 == 0)
+                        and num_tokenized_articles_lock is not None
+                        and num_tokenized_articles is not None
+                    ):
                         with num_tokenized_articles_lock:
-                            num_tokenized_articles.value += 1
+                            num_tokenized_articles.value += 100
                 except json.JSONDecodeError as exc:
                     if ignore_input_format_error:
                         with open(error_log_path, "a") as f:


### PR DESCRIPTION
## Summary
Grabbing the num tokenized articles lock every step causes overhead because all the processes are waiting for each other. This PR only updates the num tokenized articles every 100 lines, to minimize that overhead, this means the progress bar does not update every step but that is ok because it only matters for long jobs. 


## PR Checklist
- [X] My PR is less than 500 lines of code
- [X] I have added sufficient comment as docstrings in my code
- [X] I have made corresponding changes to the documentation
