### PR TITLE
[CLOUD-4610] Add gitleaks secret scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ executors:
 
 # Define the jobs we want to run for this project
 jobs:
+  gitleaks:
+    executor: base
+    steps:
+      - checkout
+      - run:
+          name: Install and run gitleaks (non-blocking)
+          command: |
+            VERSION=8.28.0
+            curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+            ./gitleaks detect --source . --redact -v --config .gitleaks.toml || echo "gitleaks reported findings (non-blocking during rollout)"
   pre-commit:
     executor: pip-tools-docker
     steps:
@@ -180,6 +190,7 @@ workflows:
     jobs:
       - pre-commit
       - test
+      - gitleaks
   build-test-publish:
     jobs:
       - pre-commit:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+# Gitleaks config for generative_data_prep. Extends the built-in default ruleset.
+title = "generative_data_prep gitleaks config"
+
+[extend]
+useDefault = true


### PR DESCRIPTION
Adds gitleaks secret scanning to this repo.

- `.gitleaks.toml` — gitleaks config; extends the default ruleset.
- `.circleci/config.yml` — adds a `gitleaks` job (full-history scan via the gitleaks binary) to the build-test workflow. Non-blocking for now: reports findings without failing the build, so we can clear false positives before enforcing.

No pre-commit hook here: the gitleaks pre-commit hook needs Go, which this repo's Python CI pre-commit job doesn't have — so gitleaks runs as a CircleCI job instead.

Part of the org-wide secret-scanning rollout (CLOUD-4610).
